### PR TITLE
chore(docs): toepassen multi-container pods voor het deployen van BRP API microservices

### DIFF
--- a/docs/adr/0002-multi-container-pods.md
+++ b/docs/adr/0002-multi-container-pods.md
@@ -19,7 +19,7 @@ subgraph Consumer
     Proxy --> CAGW
 end
 
-CAGW -- [mTLS] --> PAGW
+CAGW -- mTLS --> PAGW
 
 subgraph RvIG
     direction TB
@@ -55,7 +55,7 @@ subgraph Consumer
     User ----> CAGW
 end
 
-CAGW ----> PAGW
+CAGW -- mTLS --> PAGW
 
 subgraph P[RvIG]
     direction LR
@@ -67,8 +67,8 @@ subgraph P[RvIG]
     end
     AP ----> IDP
     API -- R --> DB
-    AP -- ["R autorisatie &
-W protocollering"] --> DB
+    AP -- "R autorisatie &
+W protocollering" --> DB
 end
 ```
 


### PR DESCRIPTION
Bekijke grafische view: https://github.com/BRP-API/brp-shared-dotnet/blob/fc2e1bd6d4e7430898a13c51078ebfa7d530f8c2/docs/adr/0002-multi-container-pods.md