### PR TITLE
ci: fix plotseling falende verblijfplaatshistorie scenarios

### DIFF
--- a/.docker/autorisatie-protocollering-proxy.yml
+++ b/.docker/autorisatie-protocollering-proxy.yml
@@ -13,6 +13,7 @@ services:
       - Db__Password=root
       - Db__Database=rvig_haalcentraal_testdata
       - OAuth__Authority=http://identityserver:6000
+      - Serilog__MinimumLevel__Override__Ocelot=Warning
     ports:
       - "8080:8080"
     volumes:

--- a/.docker/autorisatie-protocollering-proxy.yml
+++ b/.docker/autorisatie-protocollering-proxy.yml
@@ -13,7 +13,8 @@ services:
       - Db__Password=root
       - Db__Database=rvig_haalcentraal_testdata
       - OAuth__Authority=http://identityserver:6000
-      - Serilog__MinimumLevel__Override__Ocelot=Warning
+      - Serilog__MinimumLevel__Override__Elastic=Information
+      - Serilog__MinimumLevel__Override__Ocelot=Information
     ports:
       - "8080:8080"
     volumes:

--- a/.docker/autorisatie-protocollering-proxy.yml
+++ b/.docker/autorisatie-protocollering-proxy.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   autorisatie-protocollering-proxy:
     container_name: autorisatie-protocollering
@@ -19,7 +17,7 @@ services:
       - "8080:8080"
     volumes:
       - ../test-data/logs:/var/log
-      - ./configuration/ocelot.json:/app/configuration/ocelot.json
+      - ./configuration:/app/configuration
     networks:
       - brp-api-network
 

--- a/.docker/autorisatie-protocollering-proxy.yml
+++ b/.docker/autorisatie-protocollering-proxy.yml
@@ -13,8 +13,6 @@ services:
       - Db__Password=root
       - Db__Database=rvig_haalcentraal_testdata
       - OAuth__Authority=http://identityserver:6000
-      - Serilog__MinimumLevel__Override__Elastic=Information
-      - Serilog__MinimumLevel__Override__Ocelot=Information
     ports:
       - "8080:8080"
     volumes:

--- a/.docker/configuration/ocelot.json
+++ b/.docker/configuration/ocelot.json
@@ -12,8 +12,8 @@
       ]
     },
     {
-      "UpstreamPathTemplate": "/haalcentraal/api/reisdocumenten/reisdocumenten",
-      "DownstreamPathTemplate": "/haalcentraal/api/reisdocumenten/reisdocumenten",
+      "UpstreamPathTemplate": "/haalcentraal/api/brphistorie/verblijfplaatshistorie",
+      "DownstreamPathTemplate": "/haalcentraal/api/brphistorie/verblijfplaatshistorie",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
@@ -23,8 +23,8 @@
       ]
     },
     {
-      "UpstreamPathTemplate": "/haalcentraal/api/brphistorie/verblijfplaatshistorie",
-      "DownstreamPathTemplate": "/haalcentraal/api/brphistorie/verblijfplaatshistorie",
+      "UpstreamPathTemplate": "/haalcentraal/api/reisdocumenten/reisdocumenten",
+      "DownstreamPathTemplate": "/haalcentraal/api/reisdocumenten/reisdocumenten",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {

--- a/.docker/configuration/ocelot.json
+++ b/.docker/configuration/ocelot.json
@@ -12,8 +12,8 @@
       ]
     },
     {
-      "UpstreamPathTemplate": "/haalcentraal/api/brphistorie/verblijfplaatshistorie",
-      "DownstreamPathTemplate": "/haalcentraal/api/brphistorie/verblijfplaatshistorie",
+      "UpstreamPathTemplate": "/haalcentraal/api/reisdocumenten/reisdocumenten",
+      "DownstreamPathTemplate": "/haalcentraal/api/reisdocumenten/reisdocumenten",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
@@ -23,8 +23,8 @@
       ]
     },
     {
-      "UpstreamPathTemplate": "/haalcentraal/api/reisdocumenten/reisdocumenten",
-      "DownstreamPathTemplate": "/haalcentraal/api/reisdocumenten/reisdocumenten",
+      "UpstreamPathTemplate": "/haalcentraal/api/brphistorie/verblijfplaatshistorie",
+      "DownstreamPathTemplate": "/haalcentraal/api/brphistorie/verblijfplaatshistorie",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {

--- a/.docker/identityserver.yml
+++ b/.docker/identityserver.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
   identityserver:

--- a/.docker/referentie-api.yml
+++ b/.docker/referentie-api.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   referentie-api:
     container_name: referentie-api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,31 +133,31 @@ jobs:
           path: |
             test-reports
             test-data/logs
-      # - name: Push test rapportage naar brp-api.github.io repo
-      #   if: always()
-      #   uses: tech-thinker/push-to-repo@main
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.GIT_PAT_TOKEN }}
-      #   with:
-      #     source-directory: test-reports/cucumber-js/reports
-      #     destination-repository-name: brp-api.github.io
-      #     destination-github-username: BRP-API
-      #     target-branch: test-reports/autorisatie-en-protocollering
-      #     commit-message: "test rapporten van build: ${{ steps.build-run-id.outputs.build-run }}"
+      - name: Push test rapportage naar brp-api.github.io repo
+        if: always()
+        uses: tech-thinker/push-to-repo@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.GIT_PAT_TOKEN }}
+        with:
+          source-directory: test-reports/cucumber-js/reports
+          destination-repository-name: brp-api.github.io
+          destination-github-username: BRP-API
+          target-branch: test-reports/autorisatie-en-protocollering
+          commit-message: "test rapporten van build: ${{ steps.build-run-id.outputs.build-run }}"
 
-      # - name: Tag & push autz & prot container images naar registry
-      #   if: always() && (steps.changes.outputs.app == 'true' || inputs.publishType == 'authz-en-prot')
-      #   run: |
-      #     docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-latest
-      #     docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
-      #     docker push ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-latest
-      #     docker push ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
-      #     docker push ${{ env.APP_CONTAINER_IMAGE }}:latest
-      # - name: Tag & push IDP mock container images naar registry
-      #   if: always() && (steps.changes.outputs.mock == 'true' || inputs.publishType == 'authn-mock')
-      #   run: |
-      #     docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
-      #     docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
-      #     docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
-      #     docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
-      #     docker push ${{ env.MOCK_CONTAINER_IMAGE }}:latest
+      - name: Tag & push autz & prot container images naar registry
+        if: always() && (steps.changes.outputs.app == 'true' || inputs.publishType == 'authz-en-prot')
+        run: |
+          docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-latest
+          docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
+          docker push ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-latest
+          docker push ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
+          docker push ${{ env.APP_CONTAINER_IMAGE }}:latest
+      - name: Tag & push IDP mock container images naar registry
+        if: always() && (steps.changes.outputs.mock == 'true' || inputs.publishType == 'authn-mock')
+        run: |
+          docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
+          docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
+          docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
+          docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
+          docker push ${{ env.MOCK_CONTAINER_IMAGE }}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           driver: docker-container
       - name: Build container images
         run: |
-          ./scripts/containers-build.sh
+          ./scripts/containers-build.sh ci
   
       - name: Voeg identityserver toe als host naam
         uses: ./.github/actions/toevoegen-localhost-naam

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,32 +130,34 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Reports
-          path: test-reports
-      - name: Push test rapportage naar brp-api.github.io repo
-        if: always()
-        uses: tech-thinker/push-to-repo@main
-        env:
-          API_TOKEN_GITHUB: ${{ secrets.GIT_PAT_TOKEN }}
-        with:
-          source-directory: test-reports/cucumber-js/reports
-          destination-repository-name: brp-api.github.io
-          destination-github-username: BRP-API
-          target-branch: test-reports/autorisatie-en-protocollering
-          commit-message: "test rapporten van build: ${{ steps.build-run-id.outputs.build-run }}"
+          path: |
+            test-reports
+            test-data/logs
+      # - name: Push test rapportage naar brp-api.github.io repo
+      #   if: always()
+      #   uses: tech-thinker/push-to-repo@main
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.GIT_PAT_TOKEN }}
+      #   with:
+      #     source-directory: test-reports/cucumber-js/reports
+      #     destination-repository-name: brp-api.github.io
+      #     destination-github-username: BRP-API
+      #     target-branch: test-reports/autorisatie-en-protocollering
+      #     commit-message: "test rapporten van build: ${{ steps.build-run-id.outputs.build-run }}"
 
-      - name: Tag & push autz & prot container images naar registry
-        if: always() && (steps.changes.outputs.app == 'true' || inputs.publishType == 'authz-en-prot')
-        run: |
-          docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-latest
-          docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
-          docker push ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-latest
-          docker push ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
-          docker push ${{ env.APP_CONTAINER_IMAGE }}:latest
-      - name: Tag & push IDP mock container images naar registry
-        if: always() && (steps.changes.outputs.mock == 'true' || inputs.publishType == 'authn-mock')
-        run: |
-          docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
-          docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
-          docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
-          docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
-          docker push ${{ env.MOCK_CONTAINER_IMAGE }}:latest
+      # - name: Tag & push autz & prot container images naar registry
+      #   if: always() && (steps.changes.outputs.app == 'true' || inputs.publishType == 'authz-en-prot')
+      #   run: |
+      #     docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-latest
+      #     docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
+      #     docker push ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-latest
+      #     docker push ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
+      #     docker push ${{ env.APP_CONTAINER_IMAGE }}:latest
+      # - name: Tag & push IDP mock container images naar registry
+      #   if: always() && (steps.changes.outputs.mock == 'true' || inputs.publishType == 'authn-mock')
+      #   run: |
+      #     docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
+      #     docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
+      #     docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
+      #     docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
+      #     docker push ${{ env.MOCK_CONTAINER_IMAGE }}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ env:
   MOCK_PROJECT_PATH: ./src/IdentityServer
   MOCK_CSPROJ_FILE_PATH: ./src/IdentityServer/IdentityServer.csproj
   MOCK_CONTAINER_IMAGE: ghcr.io/brp-api/idp-mock
+  REF_API_PROJECT_PATH: ./src/Brp.Referentie.Api
+  REF_API_CONTAINER_IMAGE: ghcr.io/brp-api/brp-referentie-api
 
 jobs:
   continuous-integration:
@@ -63,6 +65,8 @@ jobs:
               - '${{ env.INFRA_PROJECT_PATH }}/**'
             mock:
               - '${{ env.MOCK_PROJECT_PATH }}/**'
+            ref-app:
+              - '${{ env.REF_API_PROJECT_PATH }}/**'
 
       - name: Valideer .NET solution
         uses: ./.github/actions/valideer-dotnet-solution
@@ -146,7 +150,7 @@ jobs:
           commit-message: "test rapporten van build: ${{ steps.build-run-id.outputs.build-run }}"
 
       - name: Tag & push autz & prot container images naar registry
-        if: always() && (steps.changes.outputs.app == 'true' || inputs.publishType == 'authz-en-prot')
+        if: always() && (steps.changed-project.outputs.app == 'true' || inputs.publishType == 'authz-en-prot')
         run: |
           docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-latest
           docker tag ${{ env.APP_CONTAINER_IMAGE }}:latest ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
@@ -154,10 +158,14 @@ jobs:
           docker push ${{ env.APP_CONTAINER_IMAGE }}:${{ steps.app-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
           docker push ${{ env.APP_CONTAINER_IMAGE }}:latest
       - name: Tag & push IDP mock container images naar registry
-        if: always() && (steps.changes.outputs.mock == 'true' || inputs.publishType == 'authn-mock')
+        if: always() && (steps.changed-project.outputs.mock == 'true' || inputs.publishType == 'authn-mock')
         run: |
           docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
           docker tag ${{ env.MOCK_CONTAINER_IMAGE }}:latest ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
           docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-latest
           docker push ${{ env.MOCK_CONTAINER_IMAGE }}:${{ steps.mock-version.outputs.version }}-${{ steps.build-run-id.outputs.build-run }}
           docker push ${{ env.MOCK_CONTAINER_IMAGE }}:latest
+      - name: Tage & push referentie api container image naar registry
+        if: always() && steps.changed-project.outputs.ref-app == 'true'
+        run: |
+          docker push ${{ env.REF_API_CONTAINER_IMAGE }}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           driver: docker-container
       - name: Build container images
         run: |
-          ./scripts/containers-build.sh ci
+          ./scripts/containers-build.sh
   
       - name: Voeg identityserver toe als host naam
         uses: ./.github/actions/toevoegen-localhost-naam

--- a/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
+++ b/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <Version>1.2.1</Version>
+    <Version>1.2.0</Version>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <UserSecretsId>23d76c7f-6d59-41b7-8ba9-8205b6e8e03f</UserSecretsId>
   </PropertyGroup>

--- a/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
+++ b/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.OpenIdConnectServer" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.3.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.29" />
     <PackageReference Include="Ocelot" Version="23.3.3" />
   </ItemGroup>

--- a/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
+++ b/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <UserSecretsId>23d76c7f-6d59-41b7-8ba9-8205b6e8e03f</UserSecretsId>
   </PropertyGroup>

--- a/src/Brp.AutorisatieEnProtocollering.Proxy/Validatie/RequestValidatieMiddleware.cs
+++ b/src/Brp.AutorisatieEnProtocollering.Proxy/Validatie/RequestValidatieMiddleware.cs
@@ -5,7 +5,6 @@ using Brp.Shared.Infrastructure.ProblemDetails;
 using Brp.Shared.Infrastructure.Protocollering;
 using Brp.Shared.Infrastructure.Stream;
 using Brp.Shared.Infrastructure.Validatie;
-using Serilog;
 
 namespace Brp.AutorisatieEnProtocollering.Proxy.Validatie;
 
@@ -171,7 +170,6 @@ public class RequestValidatieMiddleware
     {
         var requestedResource = GetRequestedResource(httpContext);
 
-        Serilog.Log.Warning("requestedResource: {RequestedResource}", requestedResource);
         return requestedResource switch
         {
             "personen" or

--- a/src/Brp.AutorisatieEnProtocollering.Proxy/Validatie/RequestValidatieMiddleware.cs
+++ b/src/Brp.AutorisatieEnProtocollering.Proxy/Validatie/RequestValidatieMiddleware.cs
@@ -171,6 +171,7 @@ public class RequestValidatieMiddleware
     {
         var requestedResource = GetRequestedResource(httpContext);
 
+        Serilog.Log.Warning("requestedResource: {RequestedResource}", requestedResource);
         return requestedResource switch
         {
             "personen" or

--- a/src/Brp.Referentie.Api/Brp.Referentie.Api.csproj
+++ b/src/Brp.Referentie.Api/Brp.Referentie.Api.csproj
@@ -5,13 +5,13 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <Version>1.0.0+$([System.DateTime]::Now.ToString(yyyyMMddHH))</Version>
+    <Version>1.0.0</Version>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.31" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.32" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Brp.Shared.Infrastructure/Brp.Shared.Infrastructure.csproj
+++ b/src/Brp.Shared.Infrastructure/Brp.Shared.Infrastructure.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Destructurama.JsonNet" Version="3.0.0" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.11.1" />
     <PackageReference Include="FluentValidation" Version="11.9.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.31" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.32" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Include="Serilog.Enrichers.Sensitive" Version="1.7.3" />

--- a/src/IdentityServer/IdentityServer.csproj
+++ b/src/IdentityServer/IdentityServer.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Duende.IdentityServer" Version="7.0.5" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
 
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
 	</ItemGroup>

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -26,3 +26,5 @@ services:
     build:
       context: .
       dockerfile: Brp.Referentie.Api/Dockerfile
+      platforms:
+        - linux/amd64


### PR DESCRIPTION
De plotseling falend verblijfplaatshistorie scenarios blijken te zijn veroorzaakt door verwijzingen naar oudere container image layers waar de verblijfplaatshistorie implementatie niet in zit. Dit is mogelijk veroorzaakt door het proberen werkende te krijgen van het bouwen van multi-platform container images.

andere aanpassingen:
- Nuget packages geupdate
- cleanup van de container manifests
- opnemen van de logs in de upload artifacts
- pushen van de referentie-api container image. Hierdoor kunnen de feature bestanden in deze repo worden uitgevoerd zonder eerst de container images lokaal te builden