### PR TITLE
fix(logging): afvangen mogelijke deserialisatie excepties bij het voorrbereiden van een logregel

### DIFF
--- a/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
+++ b/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <UserSecretsId>23d76c7f-6d59-41b7-8ba9-8205b6e8e03f</UserSecretsId>
   </PropertyGroup>

--- a/src/Brp.Shared.Infrastructure/Logging/SerilogHelpers.cs
+++ b/src/Brp.Shared.Infrastructure/Logging/SerilogHelpers.cs
@@ -257,15 +257,29 @@ public static class SerilogHelpers
                 case LogConstants.Autorisatie:
                 case LogConstants.RequestHeaders:
                 case LogConstants.ResponseHeaders:
-                    diagnosticContext.Set(key, JObject.Parse(item.Value!.ToJsonCompact()), true);
+                    try
+                    {
+                        diagnosticContext.Set(key, JObject.Parse(item.Value!.ToJsonCompact()), true);
+                    }
+                    catch
+                    {
+                        diagnosticContext.Set("error", $"destructuring voorbereiding gefaald voor '{key}'");
+                    }
                     break;
                 case MapToEcsKeys.EcsRequestBody:
                 case MapToEcsKeys.EcsResponseBody:
                     var val = item.Value as string;
                     if (!string.IsNullOrWhiteSpace(val))
                     {
-                        // remove 'ecs.' from property name
-                        diagnosticContext.Set(key[4..], JObject.Parse(val!), true);
+                        try
+                        {
+                            // remove 'ecs.' from property name
+                            diagnosticContext.Set(key[4..], JObject.Parse(val!), true);
+                        }
+                        catch
+                        {
+                            diagnosticContext.Set("error", $"destructuring voorbereiding gefaald voor {key[4..]}");
+                        }
                     }
                     break;
                 case LogConstants.Protocollering:


### PR DESCRIPTION
objecten en json strings worden omgezet naar json objecten zodat zij als een destructured object kunnen worden toegevoegd aan de log context. Wanneer een exceptie optreedt bij de deserialisatie proces, wordt het vullen van de log context afgebroken en ontbreken er hierdoor voor monitoring noodzakelijke velden

closes: #57 