### PR TITLE
fix(A&P): afhandeling 500 response van downstream api gecorrigeerd

### DIFF
--- a/features/validatie/response-afhandeling.feature
+++ b/features/validatie/response-afhandeling.feature
@@ -1,0 +1,33 @@
+#language: nl
+
+Functionaliteit: correcte afhandeling van een downstream api response
+
+  Regel: Een downstream api response met status 500 wordt als interne server fout geleverd
+
+    @fout-case
+    Scenario: de aanroep van een downstream api resulteert in een 500 response 
+      Gegeven de response van de downstream api heeft de volgende headers
+      | status | Content-Type             |
+      | 500    | application/problem+json |
+      En de response van de downstream api heeft de volgende body
+      """
+      {
+          "type": "https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1",
+          "title": "Name or service not known (gezag-api:8080)",
+          "status": 500,
+          "detail": "Name or service not known",
+          "instance": "/haalcentraal/api/brp/personen",
+          "code": "serverError"
+      }
+      """
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000012                       |
+      | fields              | burgerservicenummer             |
+      Dan heeft de response de volgende gegevens
+      | naam     | waarde                                                      |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1 |
+      | title    | Internal Server error.                                      |
+      | status   | 500                                                         |
+      | instance | /haalcentraal/api/brp/personen                              |

--- a/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
+++ b/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <UserSecretsId>23d76c7f-6d59-41b7-8ba9-8205b6e8e03f</UserSecretsId>
   </PropertyGroup>

--- a/src/Brp.Referentie.Api/Controllers/PersoonController.cs
+++ b/src/Brp.Referentie.Api/Controllers/PersoonController.cs
@@ -16,7 +16,12 @@ public class PersoonController : ControllerBase
     Route("personen")]
     public async Task<IActionResult> Index([FromBody]object body)
     {
-        await HttpContext.Response.AddCustomResponseHeaders(_environment);
+        int status = await HttpContext.Response.AddCustomResponseHeaders(_environment);
+
+        if (await HttpContext.Response.AddCustomResponseBody(_environment))
+        {
+            return StatusCode(status);
+        }
 
         return Ok(new { personen = new List<object>() });
     }

--- a/src/Brp.Referentie.Api/Helpers.cs
+++ b/src/Brp.Referentie.Api/Helpers.cs
@@ -4,8 +4,10 @@ namespace Brp.Referentie.Api;
 
 public static class Helpers
 {
-    public static async Task AddCustomResponseHeaders(this HttpResponse response, IWebHostEnvironment environment)
+    public static async Task<int> AddCustomResponseHeaders(this HttpResponse response, IWebHostEnvironment environment)
     {
+        var retval = StatusCodes.Status200OK;
+
         var path = Path.Combine(environment.ContentRootPath, "Data", "response-headers.json");
         if (File.Exists(path))
         {
@@ -14,10 +16,16 @@ public static class Helpers
             var responseHeaders = JObject.Parse(data);
             foreach (var header in responseHeaders)
             {
-                response.Headers.Add(header.Key, header.Value?.ToString());
+                if(header.Key.Equals("status", StringComparison.OrdinalIgnoreCase))
+                {
+                    retval = int.Parse(header.Value!.ToString());
+                }
+                response.Headers.Add(header.Key, header.Value!.ToString());
             }
 
         }
+
+        return retval;
     }
 
     public static async Task<bool> AddCustomResponseBody(this HttpResponse response, IWebHostEnvironment environment)

--- a/src/Brp.Shared.Infrastructure/ProblemDetails/InternalServerErrorHandler.cs
+++ b/src/Brp.Shared.Infrastructure/ProblemDetails/InternalServerErrorHandler.cs
@@ -9,6 +9,8 @@ public static class InternalServerErrorHandler
     {
         var problemDetails = context.Request.CreateProblemDetailsFor(StatusCodes.Status500InternalServerError);
 
+        context.Response.Clear();
+
         await context.Response.WriteProblemDetailsAsync(problemDetails);
     }
 }


### PR DESCRIPTION
de response is in dit geval ongeldige json (2 geconcateneerde json objecten) en metadata.reponse.body bevat geen internal server response

fixes #61 