### PR TITLE
toevoegen detail met betreffende velden bij unauthorizedField response

### DIFF
--- a/features/autorisatie/personen/autorisatie.feature
+++ b/features/autorisatie/personen/autorisatie.feature
@@ -130,12 +130,13 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | burgerservicenummer | 000000024                                                         |
       | fields              | burgerservicenummer,geboorte.datum,geboorte.plaats,naam.voornamen |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                     |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                    |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: geboorte.plaats |
+      | status   | 403                                                                                        |
+      | code     | unauthorizedField                                                                          |
+      | instance | /haalcentraal/api/brp/personen                                                             |
 
     @fout-case
     Scenario: Afnemer vraagt om meerdere velden (geboorteplaatsen geboorteland) waarvoor deze niet geautoriseerd is
@@ -151,12 +152,13 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | burgerservicenummer | 000000024                                    |
       | fields              | geboorte.datum,geboorte.plaats,geboorte.land |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                               |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                   |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: geboorte.plaats, geboorte.land |
+      | status   | 403                                                                                                       |
+      | code     | unauthorizedField                                                                                         |
+      | instance | /haalcentraal/api/brp/personen                                                                            |
 
     @fout-case
     Abstract Scenario: Afnemer vraagt om gegevensgroep <fields> en is niet geautoriseerd voor <missende autorisatie>
@@ -172,12 +174,13 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields          | ad hoc rubrieken              | missende autorisatie                         |
@@ -376,12 +379,13 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | burgerservicenummer | 000000024                       |
       | fields              | verblijfplaats.functieAdres     |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                                 |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                            |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: verblijfplaats.functieAdres |
+      | status   | 403                                                                                                    |
+      | code     | unauthorizedField                                                                                      |
+      | instance | /haalcentraal/api/brp/personen                                                                         |
 
     Scenario: Autorisatie voor gevraagd veld is toegevoegd
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
@@ -469,12 +473,13 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | burgerservicenummer | 000000024                              |
       | fields              | burgerservicenummer,naam.geslachtsnaam |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                        |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                   |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                       |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: naam.geslachtsnaam |
+      | status   | 403                                                                                           |
+      | code     | unauthorizedField                                                                             |
+      | instance | /haalcentraal/api/brp/personen                                                                |
 
     Scenario: Autorisatie voor gevraagd gegeven wordt vanaf morgen ingetrokken
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens

--- a/features/autorisatie/personen/autorisatie.feature
+++ b/features/autorisatie/personen/autorisatie.feature
@@ -155,7 +155,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | naam     | waarde                                                                                                    |
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                               |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                   |
-      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: geboorte.plaats, geboorte.land |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: geboorte.land, geboorte.plaats |
       | status   | 403                                                                                                       |
       | code     | unauthorizedField                                                                                         |
       | instance | /haalcentraal/api/brp/personen                                                                            |

--- a/features/autorisatie/personen/fields-alias-autorisatie.feature
+++ b/features/autorisatie/personen/fields-alias-autorisatie.feature
@@ -19,12 +19,13 @@ Regel: de 'adresseringBinnenland' field alias moet worden gebruikt door een cons
     | burgerservicenummer | 000000097                       |
     | fields              | <field>                         |
     Dan heeft de response de volgende gegevens
-    | naam     | waarde                                                                  |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-    | status   | 403                                                                     |
-    | code     | unauthorizedField                                                       |
-    | instance | /haalcentraal/api/brp/personen                                          |
+    | naam     | waarde                                                                             |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                        |
+    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.            |
+    | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <field> |
+    | status   | 403                                                                                |
+    | code     | unauthorizedField                                                                  |
+    | instance | /haalcentraal/api/brp/personen                                                     |
 
     Voorbeelden:
     | field                   |
@@ -41,12 +42,13 @@ Regel: de 'adresseringBinnenland' field alias moet worden gebruikt door een cons
     | adresseerbaarObjectIdentificatie | 0599010051001502                        |
     | fields                           | <field>                                 |
     Dan heeft de response de volgende gegevens
-    | naam     | waarde                                                                  |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-    | status   | 403                                                                     |
-    | code     | unauthorizedField                                                       |
-    | instance | /haalcentraal/api/brp/personen                                          |
+    | naam     | waarde                                                                             |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                        |
+    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.            |
+    | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <field> |
+    | status   | 403                                                                                |
+    | code     | unauthorizedField                                                                  |
+    | instance | /haalcentraal/api/brp/personen                                                     |
 
     Voorbeelden:
     | field                   |
@@ -63,12 +65,13 @@ Regel: de 'adresseringBinnenland' field alias moet worden gebruikt door een cons
     | nummeraanduidingIdentificatie | 0599010051001501                     |
     | fields                        | <field>                              |
     Dan heeft de response de volgende gegevens
-    | naam     | waarde                                                                  |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-    | status   | 403                                                                     |
-    | code     | unauthorizedField                                                       |
-    | instance | /haalcentraal/api/brp/personen                                          |
+    | naam     | waarde                                                                             |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                        |
+    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.            |
+    | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <field> |
+    | status   | 403                                                                                |
+    | code     | unauthorizedField                                                                  |
+    | instance | /haalcentraal/api/brp/personen                                                     |
 
     Voorbeelden:
     | field                   |
@@ -87,12 +90,13 @@ Regel: de 'verblijfplaatsBinnenland' field alias moet worden gebruikt door een c
     | burgerservicenummer | 000000097                       |
     | fields              | <field>                         |
     Dan heeft de response de volgende gegevens
-    | naam     | waarde                                                                  |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-    | status   | 403                                                                     |
-    | code     | unauthorizedField                                                       |
-    | instance | /haalcentraal/api/brp/personen                                          |
+    | naam     | waarde                                                                             |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                        |
+    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.            |
+    | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <field> |
+    | status   | 403                                                                                |
+    | code     | unauthorizedField                                                                  |
+    | instance | /haalcentraal/api/brp/personen                                                     |
 
     Voorbeelden:
     | field                               |

--- a/features/autorisatie/personen/gezag-persoon-beperkt/adressering/autorisatie.feature
+++ b/features/autorisatie/personen/gezag-persoon-beperkt/adressering/autorisatie.feature
@@ -44,12 +44,13 @@ Regel: Vragen met fields om een adres in adressering wanneer de gebruiker niet g
     | adresseerbaarObjectIdentificatie | 0599010051001502                        |
     | fields                           | <fields>                                |
     Dan heeft de response de volgende gegevens
-    | naam     | waarde                                                                  |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-    | status   | 403                                                                     |
-    | code     | unauthorizedField                                                       |
-    | instance | /haalcentraal/api/brp/personen                                          |
+    | naam     | waarde                                                                              |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+    | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+    | status   | 403                                                                                 |
+    | code     | unauthorizedField                                                                   |
+    | instance | /haalcentraal/api/brp/personen                                                      |
 
     Voorbeelden:
     | fields                            | ad hoc rubrieken                                                                                                          | missende autorisatie |

--- a/features/autorisatie/personen/gezag-persoon-beperkt/autorisatie.feature
+++ b/features/autorisatie/personen/gezag-persoon-beperkt/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van Persoon bij zoeken
     | adresseerbaarObjectIdentificatie | 0599010051001502                        |
     | fields                           | <fields>                                |
     Dan heeft de response de volgende gegevens
-    | naam     | waarde                                                                  |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-    | status   | 403                                                                     |
-    | code     | unauthorizedField                                                       |
-    | instance | /haalcentraal/api/brp/personen                                          |
+    | naam     | waarde                                                                              |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+    | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+    | status   | 403                                                                                 |
+    | code     | unauthorizedField                                                                   |
+    | instance | /haalcentraal/api/brp/personen                                                      |
 
     Voorbeelden:
     | fields                | missende autorisatie |

--- a/features/autorisatie/personen/gezag-persoon-beperkt/geboorte/autorisatie.feature
+++ b/features/autorisatie/personen/gezag-persoon-beperkt/geboorte/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van geboorte van persoon bij zoeken
       | adresseerbaarObjectIdentificatie | 0599010051001502                        |
       | fields                           | <fields>                                |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                     | missende autorisatie |

--- a/features/autorisatie/personen/gezag-persoon-beperkt/gezag/autorisatie.feature
+++ b/features/autorisatie/personen/gezag-persoon-beperkt/gezag/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van gezag van Gezag Persoon Beperkt
       | adresseerbaarObjectIdentificatie | 0599010000219679                        |
       | fields                           | gezag                                   |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                           |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                      |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.          |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: gezag |
+      | status   | 403                                                                              |
+      | code     | unauthorizedField                                                                |
+      | instance | /haalcentraal/api/brp/personen                                                   |
 
     Scenario: Afnemer vraagt gezag, en heeft uitsluitend de autorisatie die nodig is om deze vraag te mogen stellen
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens

--- a/features/autorisatie/personen/gezag-persoon-beperkt/leeftijd/autorisatie.feature
+++ b/features/autorisatie/personen/gezag-persoon-beperkt/leeftijd/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van leeftijd van persoon bij zoeken
       | adresseerbaarObjectIdentificatie | 0599010051001502                        |
       | fields                           | <fields>                                |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields   | missende autorisatie | ad hoc rubrieken                                |

--- a/features/autorisatie/personen/gezag-persoon-beperkt/naam/autorisatie.feature
+++ b/features/autorisatie/personen/gezag-persoon-beperkt/naam/autorisatie.feature
@@ -19,12 +19,13 @@ Regel: Wanneer met fields gevraagd wordt om een veld waarvoor de gebruiker niet 
     | adresseerbaarObjectIdentificatie | 0599010051001502                        |
     | fields                           | <fields>                                |
     Dan heeft de response de volgende gegevens
-    | naam     | waarde                                                                  |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-    | status   | 403                                                                     |
-    | code     | unauthorizedField                                                       |
-    | instance | /haalcentraal/api/brp/personen                                          |
+    | naam     | waarde                                                                              |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+    | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+    | status   | 403                                                                                 |
+    | code     | unauthorizedField                                                                   |
+    | instance | /haalcentraal/api/brp/personen                                                      |
 
     Voorbeelden:
     | fields                                    | ad hoc rubrieken                | missende autorisatie |

--- a/features/autorisatie/personen/persoon-beperkt/adressering/autorisatie.feature
+++ b/features/autorisatie/personen/persoon-beperkt/adressering/autorisatie.feature
@@ -46,12 +46,13 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
       | geboortedatum | 1983-05-26                          |
       | fields        | <fields>                            |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                            | ad hoc rubrieken                                                                                                          | missende autorisatie |

--- a/features/autorisatie/personen/persoon-beperkt/autorisatie.feature
+++ b/features/autorisatie/personen/persoon-beperkt/autorisatie.feature
@@ -18,12 +18,13 @@ Functionaliteit: autorisatie gegevens van Persoon bij zoeken
       | geboortedatum | 1983-05-26                          |
       | fields        | <fields>                            |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                | missende autorisatie | ad hoc rubrieken                                            |

--- a/features/autorisatie/personen/persoon-beperkt/geboorte/autorisatie.feature
+++ b/features/autorisatie/personen/persoon-beperkt/geboorte/autorisatie.feature
@@ -20,12 +20,13 @@ Functionaliteit: autorisatie gegevens van geboorte van persoon bij zoeken
       | huisnummer | 2                           |
       | fields     | <fields>                    |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                     | missende autorisatie | ad hoc rubrieken                          |

--- a/features/autorisatie/personen/persoon-beperkt/leeftijd/autorisatie.feature
+++ b/features/autorisatie/personen/persoon-beperkt/leeftijd/autorisatie.feature
@@ -20,12 +20,13 @@ Functionaliteit: autorisatie gegevens van leeftijd van persoon bij zoeken
       | huisnummer | 2                           |
       | fields     | <fields>                    |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields   | missende autorisatie | ad hoc rubrieken                                |

--- a/features/autorisatie/personen/persoon-beperkt/naam/autorisatie.feature
+++ b/features/autorisatie/personen/persoon-beperkt/naam/autorisatie.feature
@@ -20,12 +20,13 @@ Functionaliteit: Autorisatie voor naam in PersoonBeperkt
       | huisnummer | 2                           |
       | fields     | <fields>                    |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                    | ad hoc rubrieken                | missende autorisatie |

--- a/features/autorisatie/personen/persoon/adressering/aanhef/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/adressering/aanhef/autorisatie.feature
@@ -38,12 +38,13 @@ Functionaliteit: autorisatie voor aanhef
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                       |

--- a/features/autorisatie/personen/persoon/adressering/aanschrijfwijze/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/adressering/aanschrijfwijze/autorisatie.feature
@@ -42,12 +42,13 @@ Functionaliteit: autorisatie voor aanschrijfwijze
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                              | ad hoc rubrieken                                                               | missende autorisatie                    |

--- a/features/autorisatie/personen/persoon/adressering/adres-regels/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/adressering/adres-regels/autorisatie.feature
@@ -42,12 +42,13 @@ Functionaliteit: autorisatie adressering adresregels Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                            | ad hoc rubrieken                                                                                                    | missende autorisatie |

--- a/features/autorisatie/personen/persoon/adressering/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/adressering/autorisatie.feature
@@ -38,12 +38,13 @@ Functionaliteit: autorisatie adressering Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                | ad hoc rubrieken                                                                                                    | missende autorisatie                  |

--- a/features/autorisatie/personen/persoon/adressering/gebruikinlopendetekst/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/adressering/gebruikinlopendetekst/autorisatie.feature
@@ -38,12 +38,13 @@ Functionaliteit: autorisatie voor gebruikInLopendeTekst
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                      |

--- a/features/autorisatie/personen/persoon/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van Persoon
     | burgerservicenummer | 000000024                       |
     | fields              | <fields>                        |
     Dan heeft de response de volgende gegevens
-    | naam     | waarde                                                                  |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-    | status   | 403                                                                     |
-    | code     | unauthorizedField                                                       |
-    | instance | /haalcentraal/api/brp/personen                                          |
+    | naam     | waarde                                                                              |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+    | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+    | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+    | status   | 403                                                                                 |
+    | code     | unauthorizedField                                                                   |
+    | instance | /haalcentraal/api/brp/personen                                                      |
 
     Voorbeelden:
     | fields                     | missende autorisatie | ad hoc rubrieken                                      |

--- a/features/autorisatie/personen/persoon/europees-kiesrecht/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/europees-kiesrecht/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van Europees kiesrecht van Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                             | missende autorisatie | ad hoc rubrieken            |

--- a/features/autorisatie/personen/persoon/geboorte/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/geboorte/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van geboortegegevens van Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                       | missende autorisatie | ad hoc rubrieken                                                              |

--- a/features/autorisatie/personen/persoon/gemeente/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/gemeente/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van gemeente van persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                  | missende autorisatie                                                    | ad hoc rubrieken                                                         |

--- a/features/autorisatie/personen/persoon/gezag/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/gezag/autorisatie.feature
@@ -9,46 +9,46 @@ Functionaliteit: autorisatie gegevens van gezag van Persoon
       | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | 10120 113210 113310             | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
+      | naam      | waarde |
+      | afnemerID | 000008 |
       Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 000000012                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                              |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
-      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
-      | status   | 403                                                                                 |
-      | code     | unauthorizedField                                                                   |
-      | instance | /haalcentraal/api/brp/personen                                                      |
+      | naam     | waarde                                                                                                  |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                             |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                 |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <niet geautoriseerde velden> |
+      | status   | 403                                                                                                     |
+      | code     | unauthorizedField                                                                                       |
+      | instance | /haalcentraal/api/brp/personen                                                                          |
 
       Voorbeelden:
-      | fields                                     |
-      | gezag                                      |
-      | gezag.type                                 |
-      | gezag.minderjarige                         |
-      | gezag.ouders                               |
-      | gezag.ouder                                |
-      | gezag.derde                                |
-      | gezag.derden                               |
-      | gezag.minderjarige.burgerservicenummer     |
-      | gezag.ouders.burgerservicenummer           |
-      | gezag.ouder.burgerservicenummer            |
-      | gezag.derde.burgerservicenummer            |
-      | gezag.derden.burgerservicenummer           |
-      | gezag.ouders,gezag.ouder                   |
-      | gezag.type,gezag.minderjarige,gezag.ouders |
+      | fields                                     | niet geautoriseerde velden                   |
+      | gezag                                      | gezag                                        |
+      | gezag.type                                 | gezag.type                                   |
+      | gezag.minderjarige                         | gezag.minderjarige                           |
+      | gezag.ouders                               | gezag.ouders                                 |
+      | gezag.ouder                                | gezag.ouder                                  |
+      | gezag.derde                                | gezag.derde                                  |
+      | gezag.derden                               | gezag.derden                                 |
+      | gezag.minderjarige.burgerservicenummer     | gezag.minderjarige.burgerservicenummer       |
+      | gezag.ouders.burgerservicenummer           | gezag.ouders.burgerservicenummer             |
+      | gezag.ouder.burgerservicenummer            | gezag.ouder.burgerservicenummer              |
+      | gezag.derde.burgerservicenummer            | gezag.derde.burgerservicenummer              |
+      | gezag.derden.burgerservicenummer           | gezag.derden.burgerservicenummer             |
+      | gezag.ouders,gezag.ouder                   | gezag.ouder, gezag.ouders                    |
+      | gezag.type,gezag.minderjarige,gezag.ouders | gezag.minderjarige, gezag.ouders, gezag.type |
 
     Abstract Scenario: Afnemer vraagt <fields>, en heeft uitsluitend de autorisatie die nodig is om deze vraag te mogen stellen
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
       | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | 10120 PAGZ01                    | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
+      | naam      | waarde |
+      | afnemerID | 000008 |
       Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -57,17 +57,17 @@ Functionaliteit: autorisatie gegevens van gezag van Persoon
       Dan heeft de response 0 personen
 
       Voorbeelden:
-      | fields                                     |
-      | gezag                                      |
-      | gezag.type                                 |
-      | gezag.minderjarige                         |
-      | gezag.ouders                               |
-      | gezag.ouder                                |
-      | gezag.derde                                |
-      | gezag.derden                               |
-      | gezag.minderjarige.burgerservicenummer     |
-      | gezag.ouders.burgerservicenummer           |
-      | gezag.ouder.burgerservicenummer            |
-      | gezag.derde.burgerservicenummer            |
-      | gezag.derden.burgerservicenummer           |
-      | gezag.ouders,gezag.ouder                   |
+      | fields                                 |
+      | gezag                                  |
+      | gezag.type                             |
+      | gezag.minderjarige                     |
+      | gezag.ouders                           |
+      | gezag.ouder                            |
+      | gezag.derde                            |
+      | gezag.derden                           |
+      | gezag.minderjarige.burgerservicenummer |
+      | gezag.ouders.burgerservicenummer       |
+      | gezag.ouder.burgerservicenummer        |
+      | gezag.derde.burgerservicenummer        |
+      | gezag.derden.burgerservicenummer       |
+      | gezag.ouders,gezag.ouder               |

--- a/features/autorisatie/personen/persoon/gezag/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/gezag/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van gezag van Persoon
       | burgerservicenummer | 000000012                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                     |

--- a/features/autorisatie/personen/persoon/gezagsverhouding/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/gezagsverhouding/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van gezagsverhouding van Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                  | missende autorisatie | ad hoc rubrieken |

--- a/features/autorisatie/personen/persoon/immigratie/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/immigratie/autorisatie.feature
@@ -47,12 +47,13 @@ Functionaliteit: autorisatie gegevens van immigratie van Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                           | missende autorisatie      | ad hoc rubrieken                                        |

--- a/features/autorisatie/personen/persoon/kind/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/kind/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van kindgegevens van Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                             | missende autorisatie | ad hoc rubrieken                                                         |

--- a/features/autorisatie/personen/persoon/leeftijd/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/leeftijd/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie van leeftijd van Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields   | missende autorisatie | ad hoc rubrieken                                            |

--- a/features/autorisatie/personen/persoon/naam/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/naam/autorisatie.feature
@@ -47,12 +47,13 @@ Functionaliteit: Autorisatie voor naam
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                    | ad hoc rubrieken                            | missende autorisatie |
@@ -80,12 +81,13 @@ Functionaliteit: Autorisatie voor naam
       | burgerservicenummer | 000000024                       |
       | fields              | naam                            |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                          |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                     |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.         |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: naam |
+      | status   | 403                                                                             |
+      | code     | unauthorizedField                                                               |
+      | instance | /haalcentraal/api/brp/personen                                                  |
 
       Voorbeelden:
       | ad hoc rubrieken                                  | missende autorisatie |

--- a/features/autorisatie/personen/persoon/nationaliteit/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/nationaliteit/autorisatie.feature
@@ -94,13 +94,13 @@ Functionaliteit: autorisatie nationaliteitgegevens Persoon
       | burgerservicenummer | 000000024                                |
       | fields              | burgerservicenummer,nationaliteiten.type |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                                        |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                   |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                       |
-      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: nationaliteit.type |
-      | status   | 403                                                                                           |
-      | code     | unauthorizedField                                                                             |
-      | instance | /haalcentraal/api/brp/personen                                                                |
+      | naam     | waarde                                                                                          |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                     |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                         |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: nationaliteiten.type |
+      | status   | 403                                                                                             |
+      | code     | unauthorizedField                                                                               |
+      | instance | /haalcentraal/api/brp/personen                                                                  |
 
     Scenario: Afnemer vraagt type, en heeft uitsluitend de autorisatie die nodig is om deze vraag te mogen stellen
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens

--- a/features/autorisatie/personen/persoon/nationaliteit/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/nationaliteit/autorisatie.feature
@@ -20,12 +20,13 @@ Functionaliteit: autorisatie nationaliteitgegevens Persoon
       | burgerservicenummer | 000000024                           |
       | fields              | burgerservicenummer,<gevraagd veld> |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                     |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                    |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <gevraagd veld> |
+      | status   | 403                                                                                        |
+      | code     | unauthorizedField                                                                          |
+      | instance | /haalcentraal/api/brp/personen                                                             |
 
       Voorbeelden:
       | gevraagd veld                                     | ad hoc rubrieken  | missende autorisatie |
@@ -93,12 +94,13 @@ Functionaliteit: autorisatie nationaliteitgegevens Persoon
       | burgerservicenummer | 000000024                                |
       | fields              | burgerservicenummer,nationaliteiten.type |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                        |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                   |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                       |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: nationaliteit.type |
+      | status   | 403                                                                                           |
+      | code     | unauthorizedField                                                                             |
+      | instance | /haalcentraal/api/brp/personen                                                                |
 
     Scenario: Afnemer vraagt type, en heeft uitsluitend de autorisatie die nodig is om deze vraag te mogen stellen
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens

--- a/features/autorisatie/personen/persoon/ouder/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/ouder/autorisatie.feature
@@ -20,12 +20,13 @@ Functionaliteit: autorisatie oudergegevens Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | ouders.ouderAanduiding          |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                            |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                       |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                           |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: ouders.ouderAanduiding |
+      | status   | 403                                                                                               |
+      | code     | unauthorizedField                                                                                 |
+      | instance | /haalcentraal/api/brp/personen                                                                    |
 
       Voorbeelden:
       | ad hoc rubrieken              | missende autorisatie                                            |
@@ -128,12 +129,13 @@ Functionaliteit: autorisatie oudergegevens Persoon
       | burgerservicenummer | 000000024                                      |
       | fields              | ouders.datumIngangFamilierechtelijkeBetrekking |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                                               |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                                   |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: ouders.datumIngangFamilierechtelijkeBetrekking |
+      | status   | 403                                                                                                                       |
+      | code     | unauthorizedField                                                                                                         |
+      | instance | /haalcentraal/api/brp/personen                                                                                            |
 
       Voorbeelden:
       | ad hoc rubrieken | missende autorisatie                                                  |
@@ -155,12 +157,13 @@ Functionaliteit: autorisatie oudergegevens Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | ouders.<fields>                 |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                     |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                    |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: ouders.<fields> |
+      | status   | 403                                                                                        |
+      | code     | unauthorizedField                                                                          |
+      | instance | /haalcentraal/api/brp/personen                                                             |
 
       Voorbeelden:
       | ad hoc rubrieken                                                                                                         | ontbrekende autorisatie | fields                                              |
@@ -268,12 +271,13 @@ Functionaliteit: autorisatie oudergegevens Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | ouders                          |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                            |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                       |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.           |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: ouders |
+      | status   | 403                                                                               |
+      | code     | unauthorizedField                                                                 |
+      | instance | /haalcentraal/api/brp/personen                                                    |
 
       Voorbeelden:
       | ad hoc rubrieken                                                                                                         | ontbrekende autorisatie | niet geautoriseerd veld                 |

--- a/features/autorisatie/personen/persoon/overlijden/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/overlijden/autorisatie.feature
@@ -20,12 +20,13 @@ Functionaliteit: autorisatie gegevens van overlijden van Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                         | missende autorisatie | ad hoc rubrieken |

--- a/features/autorisatie/personen/persoon/partner/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/partner/autorisatie.feature
@@ -10,8 +10,8 @@ Functionaliteit: autorisatie partners
       | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | 10120 <ad hoc rubrieken>        | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
+      | naam      | waarde |
+      | afnemerID | 000008 |
       Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -53,8 +53,8 @@ Functionaliteit: autorisatie partners
       | Rubrieknummer ad hoc (35.95.60)                                                                  | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | 10120 50120 50210 50220 50230 50240 50310 50320 50330 50410 50610 50620 50630 50710 51510 PAHP01 | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
+      | naam      | waarde |
+      | afnemerID | 000008 |
       Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -68,8 +68,8 @@ Functionaliteit: autorisatie partners
       | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | <ad hoc rubrieken>              | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
+      | naam      | waarde |
+      | afnemerID | 000008 |
       Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -108,21 +108,21 @@ Functionaliteit: autorisatie partners
       | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | <ad hoc rubrieken>              | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
+      | naam      | waarde |
+      | afnemerID | 000008 |
       Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 000000024                       |
       | fields              | partners.<fields>               |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                              |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
-      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
-      | status   | 403                                                                                 |
-      | code     | unauthorizedField                                                                   |
-      | instance | /haalcentraal/api/brp/personen                                                      |
+      | naam     | waarde                                                                                       |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                  |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                      |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: partners.<fields> |
+      | status   | 403                                                                                          |
+      | code     | unauthorizedField                                                                            |
+      | instance | /haalcentraal/api/brp/personen                                                               |
 
       Voorbeelden:
       | fields                               | ad hoc rubrieken                                                                           | missende autorisatie |
@@ -172,8 +172,8 @@ Functionaliteit: autorisatie partners
       | Rubrieknummer ad hoc (35.95.60)            | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
       | 10120 50120 50210 50220 50230 50240 PAHP01 | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
-      | naam         | waarde |
-      | afnemerID    | 000008 |
+      | naam      | waarde |
+      | afnemerID | 000008 |
       En de persoon met burgerservicenummer '000000061' heeft een 'partner' met de volgende gegevens
       | naam                                                               | waarde          |
       | voornamen (02.10)                                                  | Daan            |

--- a/features/autorisatie/personen/persoon/partner/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/partner/autorisatie.feature
@@ -76,12 +76,13 @@ Functionaliteit: autorisatie partners
       | burgerservicenummer | 000000024                       |
       | fields              | partners                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: partners |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | ad hoc rubrieken                                                                           | missende autorisatie |
@@ -115,12 +116,13 @@ Functionaliteit: autorisatie partners
       | burgerservicenummer | 000000024                       |
       | fields              | partners.<fields>               |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                               | ad hoc rubrieken                                                                           | missende autorisatie |

--- a/features/autorisatie/personen/persoon/uitsluiting-kiesrecht/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/uitsluiting-kiesrecht/autorisatie.feature
@@ -17,12 +17,13 @@ Functionaliteit: autorisatie gegevens van uitsluiting kiesrecht van Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                       | missende autorisatie | ad hoc rubrieken            |

--- a/features/autorisatie/personen/persoon/verblijfplaats/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/verblijfplaats/autorisatie.feature
@@ -346,13 +346,13 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | burgerservicenummer | 000000024                                                    |
       | fields              | burgerservicenummer,verblijfplaatsBinnenland.<gevraagd veld> |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                                                             |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                                        |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                            |
-      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: verblijfplaatsBinnenland<gevraagd veld> |
-      | status   | 403                                                                                                                |
-      | code     | unauthorizedField                                                                                                  |
-      | instance | /haalcentraal/api/brp/personen                                                                                     |
+      | naam     | waarde                                                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: verblijfplaatsBinnenland.<gevraagd veld> |
+      | status   | 403                                                                                                                 |
+      | code     | unauthorizedField                                                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                                                      |
 
       Voorbeelden:
       | gevraagd veld                                      | ad hoc rubrieken                                                                                 | missende autorisatie |

--- a/features/autorisatie/personen/persoon/verblijfplaats/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/verblijfplaats/autorisatie.feature
@@ -73,12 +73,13 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | burgerservicenummer | 000000024                                          |
       | fields              | burgerservicenummer,verblijfplaats.<gevraagd veld> |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                               |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                   |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: verblijfplaats.<gevraagd veld> |
+      | status   | 403                                                                                                       |
+      | code     | unauthorizedField                                                                                         |
+      | instance | /haalcentraal/api/brp/personen                                                                            |
 
       Voorbeelden:
       | gevraagd veld                                      | ad hoc rubrieken                                                                                                               | missende autorisatie |
@@ -125,12 +126,13 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | burgerservicenummer | 000000024                                        |
       | fields              | burgerservicenummer,verblijfplaats.verblijfadres |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                                  |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                             |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                 |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: verblijfplaats.verblijfadres |
+      | status   | 403                                                                                                     |
+      | code     | unauthorizedField                                                                                       |
+      | instance | /haalcentraal/api/brp/personen                                                                          |
 
       Voorbeelden:
       | ontbrekende autorisatie veld                    | ad hoc rubrieken                                                                                                               | missende autorisatie |
@@ -166,12 +168,13 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | burgerservicenummer | 000000024                          |
       | fields              | burgerservicenummer,verblijfplaats |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                               |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                   |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: verblijfplaats |
+      | status   | 403                                                                                       |
+      | code     | unauthorizedField                                                                         |
+      | instance | /haalcentraal/api/brp/personen                                                            |
 
       Voorbeelden:
       | ontbrekende autorisatie veld                    | ad hoc rubrieken                                                                                                               | missende autorisatie |
@@ -265,12 +268,13 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | verblijfplaats.type             |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                         |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                    |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                        |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: verblijfplaats.type |
+      | status   | 403                                                                                            |
+      | code     | unauthorizedField                                                                              |
+      | instance | /haalcentraal/api/brp/personen                                                                 |
 
       Voorbeelden:
       | ad hoc rubrieken | missende autorisatie        |
@@ -342,12 +346,13 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | burgerservicenummer | 000000024                                                    |
       | fields              | burgerservicenummer,verblijfplaatsBinnenland.<gevraagd veld> |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                                             |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                                        |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                                            |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: verblijfplaatsBinnenland<gevraagd veld> |
+      | status   | 403                                                                                                                |
+      | code     | unauthorizedField                                                                                                  |
+      | instance | /haalcentraal/api/brp/personen                                                                                     |
 
       Voorbeelden:
       | gevraagd veld                                      | ad hoc rubrieken                                                                                 | missende autorisatie |
@@ -387,12 +392,13 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <gevraagd veld>                 |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                     |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                    |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <gevraagd veld> |
+      | status   | 403                                                                                        |
+      | code     | unauthorizedField                                                                          |
+      | instance | /haalcentraal/api/brp/personen                                                             |
 
       Voorbeelden:
       | gevraagd veld                          | ad hoc rubrieken                                                                                 | missende autorisatie |
@@ -463,12 +469,13 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | verblijfplaats.type             |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                                         |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                    |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.                        |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: verblijfplaats.type |
+      | status   | 403                                                                                            |
+      | code     | unauthorizedField                                                                              |
+      | instance | /haalcentraal/api/brp/personen                                                                 |
 
       Voorbeelden:
       | ad hoc rubrieken | missende autorisatie        |

--- a/features/autorisatie/personen/persoon/verblijfstitel/autorisatie.feature
+++ b/features/autorisatie/personen/persoon/verblijfstitel/autorisatie.feature
@@ -20,12 +20,13 @@ Functionaliteit: autorisatie gegevens van verblijfstitelgegevens van Persoon
       | burgerservicenummer | 000000024                       |
       | fields              | <fields>                        |
       Dan heeft de response de volgende gegevens
-      | naam     | waarde                                                                  |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
-      | status   | 403                                                                     |
-      | code     | unauthorizedField                                                       |
-      | instance | /haalcentraal/api/brp/personen                                          |
+      | naam     | waarde                                                                              |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.             |
+      | detail   | U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: <fields> |
+      | status   | 403                                                                                 |
+      | code     | unauthorizedField                                                                   |
+      | instance | /haalcentraal/api/brp/personen                                                      |
 
       Voorbeelden:
       | fields                                 | missende autorisatie | ad hoc rubrieken |

--- a/src/Brp.AutorisatieEnProtocollering.Proxy/Autorisatie/AbstractAutorisatieService.cs
+++ b/src/Brp.AutorisatieEnProtocollering.Proxy/Autorisatie/AbstractAutorisatieService.cs
@@ -113,6 +113,7 @@ public abstract class AbstractAutorisatieService : IAuthorisation
 
     protected static AuthorisationResult NietGeautoriseerdVoorFields(IEnumerable<string> nietGeautoriseerdFieldNames, int afnemerCode) =>
         NotAuthorized(title: "U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.",
+                      detail: $"U bent niet geautoriseerd om de volgende gegevens op te vragen met fields: {string.Join(", ", nietGeautoriseerdFieldNames.OrderBy(x => x))}",
                       code: "unauthorizedField",
                       reason: $"afnemer '{afnemerCode}' is niet geautoriseerd voor fields {string.Join(", ", nietGeautoriseerdFieldNames.OrderBy(x => x))}");
 

--- a/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
+++ b/src/Brp.AutorisatieEnProtocollering.Proxy/Brp.AutorisatieEnProtocollering.Proxy.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <UserSecretsId>23d76c7f-6d59-41b7-8ba9-8205b6e8e03f</UserSecretsId>
   </PropertyGroup>


### PR DESCRIPTION
N.a.v. #70

Wanneer een 403 unauthorizedField komt moet in de response vermeld worden welke gevraagde fields waarden niet geautoriseerd zijn.

Dit is toegevoegd aan de features